### PR TITLE
Feat add functionalities

### DIFF
--- a/data_model_202BC1-BM632w-8KA8WA1151100043.csv
+++ b/data_model_202BC1-BM632w-8KA8WA1151100043.csv
@@ -1,4 +1,5 @@
 Parameter,Object,Writable,Value,Value type
+LastBoot,false,true,"0",xsd:string
 DeviceID.Manufacturer,false,false,"Huawei Technologies Co., Ltd.",xsd:string
 DeviceID.OUI,false,false,202BC1,xsd:string
 DeviceID.ProductClass,false,false,BM632w,xsd:string

--- a/genieacs-sim
+++ b/genieacs-sim
@@ -12,7 +12,7 @@ if (!cluster.isPrimary) {
   const dataModel = process.env["DATA_MODEL"];
   const serialNumber = process.env["SERIAL_NUMBER"];
   const macAddress = process.env["MAC_ADDRESS"];
-  const DefaultTimeout = process.env["DEFAULT_TIMEOUT"];
+  const defaultTimeout = process.env["DEFAULT_TIMEOUT"];
 
   let device;
   const data = fs.readFileSync(dataModel);
@@ -34,7 +34,7 @@ if (!cluster.isPrimary) {
   else {
     device = JSON.parse(data);
   }
-  simulator.start(device, serialNumber, macAddress, acsUrl, DefaultTimeout);
+  simulator.start(device, serialNumber, macAddress, acsUrl, defaultTimeout);
   return;
 }
 
@@ -53,7 +53,7 @@ const program = require("commander")
   .option("-w, --wait [milliseconds]", "Waiting period between process spawning (default: 1000)", parseFloat, 1000)
   .option("-s, --serial [offset]", "Serial number offset (default: 0)", parseFloat, 0)
   .option("-a, --mac-address [address]", "MAC address (default: 20:2B:C1:E0:69:69)", "20:2B:C1:E0:69:69")
-  .option("-t, --default-timeout [seconds]", "Time inbetween reconecs for reboot and factory reset (default: 10000)",parseFloat, 10)
+  .option("-t, --default-timeout [seconds]", "Time in between reconnects for reboot and factory reset (default: 10000)",parseFloat, 10)
   .parse(process.argv);
 
 if (!/^(http|https):\/\//.test(program.acsUrl)) {

--- a/genieacs-sim
+++ b/genieacs-sim
@@ -33,7 +33,7 @@ if (!cluster.isPrimary) {
   else {
     device = JSON.parse(data);
   }
-  simulator.start(device, serialNumber, macAddress, acsUrl);
+  simulator.start(device, serialNumber, macAddress, acsUrl, program.timeout);
   return;
 }
 
@@ -52,6 +52,7 @@ const program = require("commander")
   .option("-w, --wait [milliseconds]", "Waiting period between process spawning (default: 1000)", parseFloat, 1000)
   .option("-s, --serial [offset]", "Serial number offset (default: 0)", parseFloat, 0)
   .option("-a, --mac-address [address]", "MAC address (default: 20:2B:C1:E0:69:69)", "20:2B:C1:E0:69:69")
+  .option("-t, --timeout [timeout]", "Time inbetween reconecs for reboot and factory reset (default: 10 seconds)",parseFloat, 10000)
   .parse(process.argv);
 
 if (!/^(http|https):\/\//.test(program.acsUrl)) {
@@ -64,13 +65,12 @@ cluster.on("fork", function (worker) {
 });
 
 cluster.on("exit", function (worker, code, signal) {
-    console.log(`Simulator ${worker.env["SERIAL_NUMBER"]} (${worker.env["MAC_ADDRESS"]}) died (${signal || code}). Restarting in 10 seconds...`)
+    console.log(`Simulator ${worker.env["SERIAL_NUMBER"]} (${worker.env["MAC_ADDRESS"]}) died (${signal || code}). Restarting in ${program.timeout} seconds...`)
     setTimeout(function () {
       let newWorker = cluster.fork(worker.env);
       newWorker.env = worker.env;
-    }, 10000);
+    }, program.timeout);
 });
-
 
 for (let i = 0; i < program.processes; ++i) {
   setTimeout(function () {

--- a/genieacs-sim
+++ b/genieacs-sim
@@ -70,7 +70,7 @@ cluster.on("exit", function (worker, code, signal) {
     setTimeout(function () {
       let newWorker = cluster.fork(worker.env);
       newWorker.env = worker.env;
-    }, program.defaultTimeout);
+    }, program.defaultTimeout * 1000);
 });
 
 for (let i = 0; i < program.processes; ++i) {

--- a/genieacs-sim
+++ b/genieacs-sim
@@ -2,8 +2,7 @@
 "use strict";
 
 const cluster = require("cluster");
-
-if (!cluster.isMaster) {
+if (!cluster.isPrimary) {
   const simulator = require("./simulator");
   const csvParser = require("./csv-parser");
   const fs = require("fs");
@@ -12,6 +11,7 @@ if (!cluster.isMaster) {
   const acsUrl = process.env["ACS_URL"];
   const dataModel = process.env["DATA_MODEL"];
   const serialNumber = process.env["SERIAL_NUMBER"];
+  const macAddress = process.env["MAC_ADDRESS"];
 
   let device;
   const data = fs.readFileSync(dataModel);
@@ -33,8 +33,7 @@ if (!cluster.isMaster) {
   else {
     device = JSON.parse(data);
   }
-
-  simulator.start(device, serialNumber, acsUrl);
+  simulator.start(device, serialNumber, macAddress, acsUrl);
   return;
 }
 
@@ -52,6 +51,7 @@ const program = require("commander")
   .option("-p, --processes [count]", "Number of devices to simulate (default: 1)", parseFloat, 1)
   .option("-w, --wait [milliseconds]", "Waiting period between process spawning (default: 1000)", parseFloat, 1000)
   .option("-s, --serial [offset]", "Serial number offset (default: 0)", parseFloat, 0)
+  .option("-a, --mac-address [address]", "MAC address (default: 20:2B:C1:E0:69:69)", "20:2B:C1:E0:69:69")
   .parse(process.argv);
 
 if (!/^(http|https):\/\//.test(program.acsUrl)) {
@@ -59,27 +59,28 @@ if (!/^(http|https):\/\//.test(program.acsUrl)) {
   process.exit(1);
 }
 
-cluster.on("fork", function(worker) {
-  console.log(`Simulator ${worker.env["SERIAL_NUMBER"]} started`);
+cluster.on("fork", function (worker) {
+  console.log(`Simulator ${worker.env["SERIAL_NUMBER"]} (${worker.env["MAC_ADDRESS"]}) started`);
 });
 
-cluster.on("exit", function(worker, code, signal) {
-  console.log(`Simulator ${worker.env["SERIAL_NUMBER"]} died (${signal || code}). Restarting in 10 seconds...`)
-  setTimeout(function() {
-    let newWorker = cluster.fork(worker.env);
-    newWorker.env = worker.env;
-  }, 10000);
+cluster.on("exit", function (worker, code, signal) {
+    console.log(`Simulator ${worker.env["SERIAL_NUMBER"]} (${worker.env["MAC_ADDRESS"]}) died (${signal || code}). Restarting in 10 seconds...`)
+    setTimeout(function () {
+      let newWorker = cluster.fork(worker.env);
+      newWorker.env = worker.env;
+    }, 10000);
 });
 
 
-for (let i = 0; i < program.processes; ++ i) {
-  setTimeout(function() {
+for (let i = 0; i < program.processes; ++i) {
+  setTimeout(function () {
     let env = {
       "SERIAL_NUMBER": `00000${program.serial + i}`.slice(-6),
+      "MAC_ADDRESS": program.macAddress.slice(0, -2) + i.toString().padStart(2, '0'),
       "ACS_URL": program.acsUrl,
       "DATA_MODEL": program.dataModel,
     };
     let worker = cluster.fork(env);
     worker.env = env;
-  }, i  * program.wait)
+  }, i * program.wait)
 }

--- a/genieacs-sim
+++ b/genieacs-sim
@@ -12,6 +12,7 @@ if (!cluster.isPrimary) {
   const dataModel = process.env["DATA_MODEL"];
   const serialNumber = process.env["SERIAL_NUMBER"];
   const macAddress = process.env["MAC_ADDRESS"];
+  const DefaultTimeout = process.env["DEFAULT_TIMEOUT"];
 
   let device;
   const data = fs.readFileSync(dataModel);
@@ -33,7 +34,7 @@ if (!cluster.isPrimary) {
   else {
     device = JSON.parse(data);
   }
-  simulator.start(device, serialNumber, macAddress, acsUrl, program.timeout);
+  simulator.start(device, serialNumber, macAddress, acsUrl, DefaultTimeout);
   return;
 }
 
@@ -52,7 +53,7 @@ const program = require("commander")
   .option("-w, --wait [milliseconds]", "Waiting period between process spawning (default: 1000)", parseFloat, 1000)
   .option("-s, --serial [offset]", "Serial number offset (default: 0)", parseFloat, 0)
   .option("-a, --mac-address [address]", "MAC address (default: 20:2B:C1:E0:69:69)", "20:2B:C1:E0:69:69")
-  .option("-t, --timeout [timeout]", "Time inbetween reconecs for reboot and factory reset (default: 10 seconds)",parseFloat, 10000)
+  .option("-t, --default-timeout [seconds]", "Time inbetween reconecs for reboot and factory reset (default: 10000)",parseFloat, 10)
   .parse(process.argv);
 
 if (!/^(http|https):\/\//.test(program.acsUrl)) {
@@ -65,11 +66,11 @@ cluster.on("fork", function (worker) {
 });
 
 cluster.on("exit", function (worker, code, signal) {
-    console.log(`Simulator ${worker.env["SERIAL_NUMBER"]} (${worker.env["MAC_ADDRESS"]}) died (${signal || code}). Restarting in ${program.timeout} seconds...`)
+    console.log(`Simulator ${worker.env["SERIAL_NUMBER"]} (${worker.env["MAC_ADDRESS"]}) died (${signal || code}). Restarting in ${program.defaultTimeout} seconds...`)
     setTimeout(function () {
       let newWorker = cluster.fork(worker.env);
       newWorker.env = worker.env;
-    }, program.timeout);
+    }, program.defaultTimeout);
 });
 
 for (let i = 0; i < program.processes; ++i) {
@@ -79,6 +80,7 @@ for (let i = 0; i < program.processes; ++i) {
       "MAC_ADDRESS": program.macAddress.slice(0, -2) + i.toString().padStart(2, '0'),
       "ACS_URL": program.acsUrl,
       "DATA_MODEL": program.dataModel,
+      "DEFAULT_TIMEOUT": program.defaultTimeout * 1000
     };
     let worker = cluster.fork(env);
     worker.env = env;

--- a/methods.js
+++ b/methods.js
@@ -163,7 +163,6 @@ function inform(device, event, callback) {
   return callback(inform);
 }
 
-
 const pending = [];
 
 function getPending() {
@@ -422,7 +421,7 @@ function Reboot(device, request, callback) {
   let timeout = sim.stopSession(); //stops accepting connections for timeoutseconds
   setTimeout(function() {
     sim.startSession("1 BOOT, M Reboot, 4 VALUE CHANGE");
-  }, timeout + 5000);
+  }, parseInt(timeout) + 5000);
 }
 
 function FactoryReset(device, request, callback) {

--- a/methods.js
+++ b/methods.js
@@ -419,10 +419,10 @@ function Reboot(device, request, callback) {
   let response = xmlUtils.node("cwmp:RebootResponse", {}, "");
   callback(response);
   sim.updateParameter("LastBoot", new Date().toISOString());
-  sim.stopSession(10000); //stops accepting connections for 10 seconds
+  let timeout = sim.stopSession(); //stops accepting connections for timeoutseconds
   setTimeout(function() {
     sim.startSession("1 BOOT, M Reboot, 4 VALUE CHANGE");
-  }, 15000);
+  }, timeout + 5000);
 }
 
 function FactoryReset(device, request, callback) {

--- a/methods.js
+++ b/methods.js
@@ -420,7 +420,7 @@ function Reboot(device, request, callback) {
   sim.updateParameter("LastBoot", new Date().toISOString());
   let timeout = sim.stopSession(); //stops accepting connections for timeoutseconds
   setTimeout(function() {
-    sim.startSession("1 BOOT, M Reboot, 4 VALUE CHANGE");
+    sim.startSession("1 BOOT,M Reboot,4 VALUE CHANGE");
   }, parseInt(timeout) + 5000);
 }
 

--- a/simulator.js
+++ b/simulator.js
@@ -96,7 +96,7 @@ function sendRequest(xml, callback) {
     });
   });
 
-  request.setTimeout(30000, function (err) {
+  request.setTimeout(parseInt(timeout)+30000, function (err) {
     throw new Error("Socket timed out");
   });
 
@@ -263,8 +263,8 @@ function listenForConnectionRequests(serialNumber, acsUrlOptions, callback) {
     });
 }
 
-function start(dataModel, serialNumber, macAddress, acsUrl, defaultTimes) {
-  timeout = defaultTimes;
+function start(dataModel, serialNumber, macAddress, acsUrl, defaultTimeout) {
+  timeout = defaultTimeout;
   device = dataModel;
   defaultDeviceValue = dataModel;
   if(device["LastBoot"]){

--- a/simulator.js
+++ b/simulator.js
@@ -22,6 +22,7 @@ let defaultDeviceValue = null;
 let httpAgent = null;
 let basicAuth;
 let acceptConnections = true;
+let timeout = 10000;
 
 function createSoapDocument(id, body) {
   let headerNode = xmlUtils.node(
@@ -262,7 +263,8 @@ function listenForConnectionRequests(serialNumber, acsUrlOptions, callback) {
     });
 }
 
-function start(dataModel, serialNumber, macAddress, acsUrl) {
+function start(dataModel, serialNumber, macAddress, acsUrl, defaultTimes) {
+  timeout = defaultTimes;
   device = dataModel;
   defaultDeviceValue = dataModel;
   if(device["LastBoot"]){
@@ -307,13 +309,14 @@ function start(dataModel, serialNumber, macAddress, acsUrl) {
   });
 }
 
-function stopSession(timeout) {
+function stopSession() {
   acceptConnections = false;
   console.log(`Simulator Stoped listening for requests for ${timeout}`);
   setTimeout(() => {
     acceptConnections = true;
     console.log(`Simulator resumed listening.`);
   }, timeout);
+  return timeout;
 }
 
 function updateParameter(parameter, value) {

--- a/simulator.js
+++ b/simulator.js
@@ -225,7 +225,7 @@ function listenForConnectionRequests(serialNumber, acsUrlOptions, callback) {
   let ip, port;
   // Start a dummy socket to get the used local ip
   let socket = net.createConnection({
-    port: 80,
+    port: acsUrlOptions.port,
     host: acsUrlOptions.hostname,
     family: 4
   })

--- a/simulator.js
+++ b/simulator.js
@@ -18,9 +18,10 @@ let pendingInform = false;
 let http = null;
 let requestOptions = null;
 let device = null;
+let defaultDeviceValue = null;
 let httpAgent = null;
 let basicAuth;
-
+let acceptConnections = true;
 
 function createSoapDocument(id, body) {
   let headerNode = xmlUtils.node(
@@ -33,7 +34,7 @@ function createSoapDocument(id, body) {
   let namespaces = {};
   for (let prefix in NAMESPACES)
     namespaces[`xmlns:${prefix}`] = NAMESPACES[prefix];
-  
+
   let env = xmlUtils.node("soap-env:Envelope", namespaces, [headerNode, bodyNode]);
 
   return `<?xml version="1.0" encoding="UTF-8"?>\n${env}`;
@@ -45,7 +46,7 @@ function sendRequest(xml, callback) {
 
   headers["Content-Length"] = body.length;
   headers["Content-Type"] = "text/xml; charset=\"utf-8\"";
-  headers["Authorization"]= basicAuth;
+  headers["Authorization"] = basicAuth;
 
   if (device._cookie)
     headers["Cookie"] = device._cookie;
@@ -58,20 +59,20 @@ function sendRequest(xml, callback) {
 
   Object.assign(options, requestOptions);
 
-  let request = http.request(options, function(response) {
+  let request = http.request(options, function (response) {
     let chunks = [];
     let bytes = 0;
 
-    response.on("data", function(chunk) {
+    response.on("data", function (chunk) {
       chunks.push(chunk);
       return bytes += chunk.length;
     });
 
-    return response.on("end", function() {
+    return response.on("end", function () {
       let offset = 0;
       body = Buffer.allocUnsafe(bytes);
 
-      chunks.forEach(function(chunk) {
+      chunks.forEach(function (chunk) {
         chunk.copy(body, offset, 0, chunk.length);
         return offset += chunk.length;
       });
@@ -94,7 +95,7 @@ function sendRequest(xml, callback) {
     });
   });
 
-  request.setTimeout(30000, function(err) {
+  request.setTimeout(30000, function (err) {
     throw new Error("Socket timed out");
   });
 
@@ -102,16 +103,17 @@ function sendRequest(xml, callback) {
 }
 
 function startSession(event) {
-  nextInformTimeout = null;
-  pendingInform = false;
-  const requestId = Math.random().toString(36).slice(-8);
-
-  methods.inform(device, event, function(body) {
-    let xml = createSoapDocument(requestId, body);
-    sendRequest(xml, function(xml) {
-      cpeRequest();
+    nextInformTimeout = null;
+    pendingInform = false;
+    const requestId = Math.random().toString(36).slice(-8);
+    methods.inform(device, event, function (body) {
+      if(acceptConnections){
+      let xml = createSoapDocument(requestId, body);
+      sendRequest(xml, function (xml) {
+          cpeRequest();
+      });
+    }
     });
-  });
 }
 
 
@@ -136,22 +138,22 @@ function createFaultResponse(code, message) {
 
 
 function cpeRequest() {
-  const pending = methods.getPending();
-  if (!pending) {
-    sendRequest(null, function(xml) {
-      handleMethod(xml);
+  if(acceptConnections){
+    const pending = methods.getPending();
+    if (!pending) {
+      sendRequest(null, function (xml) {
+        handleMethod(xml);
+      });
+      return;
+    }
+    const requestId = Math.random().toString(36).slice(-8);
+    pending(function (body, callback) {
+      let xml = createSoapDocument(requestId, body);
+      sendRequest(xml, function (xml) {
+          callback(xml, cpeRequest);
+      });
     });
-    return;
   }
-
-  const requestId = Math.random().toString(36).slice(-8);
-
-  pending(function(body, callback) {
-    let xml = createSoapDocument(requestId, body);
-    sendRequest(xml, function(xml) {
-      callback(xml, cpeRequest);
-    });
-  });
 }
 
 
@@ -164,7 +166,7 @@ function handleMethod(xml) {
     else if (device["InternetGatewayDevice.ManagementServer.PeriodicInformInterval"])
       informInterval = parseInt(device["InternetGatewayDevice.ManagementServer.PeriodicInformInterval"][1]);
 
-    nextInformTimeout = setTimeout(function() {
+    nextInformTimeout = setTimeout(function () {
       startSession();
     }, pendingInform ? 0 : 1000 * informInterval);
 
@@ -204,15 +206,16 @@ function handleMethod(xml) {
   if (!method) {
     let body = createFaultResponse(9000, "Method not supported");
     let xml = createSoapDocument(requestId, body);
-    sendRequest(xml, function(xml) {
+    sendRequest(xml, function (xml) {
       handleMethod(xml);
     });
     return;
   }
 
-  method(device, requestElement, function(body) {
+
+  method(device, requestElement, function (body) {
     let xml = createSoapDocument(requestId, body);
-    sendRequest(xml, function(xml) {
+    sendRequest(xml, function (xml) {
       handleMethod(xml);
     });
   });
@@ -222,22 +225,21 @@ function listenForConnectionRequests(serialNumber, acsUrlOptions, callback) {
   let ip, port;
   // Start a dummy socket to get the used local ip
   let socket = net.createConnection({
-    port: acsUrlOptions.port,
+    port: 80,
     host: acsUrlOptions.hostname,
     family: 4
   })
-  .on("error", callback)
-  .on("connect", () => {
-    ip = socket.address().address;
-    port = socket.address().port + 1;
-    socket.end();
-  })
-  .on("close", () => {
-    const connectionRequestUrl = `http://${ip}:${port}/`;
-
-    const httpServer = http.createServer((_req, res) => {
-      console.log(`Simulator ${serialNumber} got connection request`);
-      res.end();
+    .on("error", callback)
+    .on("connect", () => {
+      ip = socket.address().address;
+      port = socket.address().port + 1;
+      socket.end();
+    })
+    .on("close", () => {
+      const connectionRequestUrl = `http://${ip}:${port}/`;
+      const httpServer = http.createServer((_req, res) => {
+        console.log(`Simulator ${serialNumber} got connection request`);
+        res.end();
         // A session is ongoing when nextInformTimeout === null
         if (nextInformTimeout === null) pendingInform = true;
         else {
@@ -246,27 +248,37 @@ function listenForConnectionRequests(serialNumber, acsUrlOptions, callback) {
             startSession("6 CONNECTION REQUEST");
           }, 0);
         }
-    });
+      });
 
-    httpServer.listen(port, ip, err => {
-      if (err) return callback(err);
-      console.log(
-        `Simulator ${serialNumber} listening for connection requests on ${connectionRequestUrl}`
-      );
-      return callback(null, connectionRequestUrl);
+      httpServer.listen(port, ip, err => {
+        if (err) return callback(err);
+        console.log(
+          `Simulator ${serialNumber} listening for connection requests on ${connectionRequestUrl}`
+        );
+        if(acceptConnections){
+          return callback(null, connectionRequestUrl);
+        }
+      });
     });
-  });
 }
 
-function start(dataModel, serialNumber, acsUrl) {
+function start(dataModel, serialNumber, macAddress, acsUrl) {
   device = dataModel;
-
+  defaultDeviceValue = dataModel;
+  if(device["LastBoot"]){
+    device["LastBoot"][1] = new Date().toISOString();
+  }
   if (device["DeviceID.SerialNumber"])
     device["DeviceID.SerialNumber"][1] = serialNumber;
   if (device["Device.DeviceInfo.SerialNumber"])
     device["Device.DeviceInfo.SerialNumber"][1] = serialNumber;
   if (device["InternetGatewayDevice.DeviceInfo.SerialNumber"])
     device["InternetGatewayDevice.DeviceInfo.SerialNumber"][1] = serialNumber;
+
+  if (device["InternetGatewayDevice.WANDevice.1.WANConnectionDevice.1.WANIPConnection.1.MACAddress"])
+    device["InternetGatewayDevice.WANDevice.1.WANConnectionDevice.1.WANIPConnection.1.MACAddress"][1] = macAddress;
+  if (device["Device.WANDevice.1.WANConnectionDevice.1.WANIPConnection.1.MACAddress"])
+    device["Device.WANDevice.1.WANConnectionDevice.1.WANIPConnection.1.MACAddress"][1] = macAddress;
 
   let username = "";
   let password = "";
@@ -282,7 +294,7 @@ function start(dataModel, serialNumber, acsUrl) {
 
   requestOptions = require("url").parse(acsUrl);
   http = require(requestOptions.protocol.slice(0, -1));
-  httpAgent = new http.Agent({keepAlive: true, maxSockets: 1});
+  httpAgent = new http.Agent({ keepAlive: true, maxSockets: 1 });
 
   listenForConnectionRequests(serialNumber, requestOptions, (err, connectionRequestUrl) => {
     if (err) throw err;
@@ -291,8 +303,27 @@ function start(dataModel, serialNumber, acsUrl) {
     } else if (device["Device.ManagementServer.ConnectionRequestURL"]) {
       device["Device.ManagementServer.ConnectionRequestURL"][1] = connectionRequestUrl;
     }
-    startSession();
+    startSession("1 BOOT");
   });
 }
 
+function stopSession(timeout) {
+  acceptConnections = false;
+  console.log(`Simulator Stoped listening for requests for ${timeout}`);
+  setTimeout(() => {
+    acceptConnections = true;
+    console.log(`Simulator resumed listening.`);
+  }, timeout);
+}
+
+function updateParameter(parameter, value) {
+  device = defaultDeviceValue;
+  if(device[parameter]){
+    device[parameter][1] = value
+  }
+}
+
 exports.start = start;
+exports.startSession = startSession;
+exports.stopSession = stopSession;
+exports.updateParameter = updateParameter;


### PR DESCRIPTION
This PR aims to add the following functionalities to the simulator:

-> Factory Reset
-> Reboot
-> Dinamic MacAddress
-> "1 BOOT" event on start Session
-> Reboot - the sim responds as if it is going to reboot, updates the Reboot Parameter & LastBoot, and stops responding requests for 10 seconds. -> sends "1 BOOT, M Reboot, 4 VALUE CHANGE"
-> Configurable timeout for reboot and factory (using -t flag, e.g -t 50 will wait at least 50 seconds)

Factory Reset - the sim responds as if its going to perform a factory reset, gracefully kills the process and waits for a replica to be instantiated, parameters return to the Default from the data model -> sends "1 BOOT" event

Dinamic MacAddress - Allows for the simulator to start with a specific MAC Address.

Tested using Node.js v20.12.2
[Node.js v18](https://hub.docker.com/_/node/tags?page=1&name=18-alpine)
[Node.js v10-alpine](https://hub.docker.com/layers/library/node/10-alpine/images/sha256-cebde99cf831563626740e22b74d5122aea6124db5c0f50bf56e4fdbf7712df1)

Any suggestion for improvement will be greatly appreciated :D

e.g for a run with a specific mac adress:

node ./genieacs-sim -u **your CWMP instance here** -s 9998 -a 11:22:33:44:55:65;
