### PR TITLE
PDM-579 Fix the firmware upgrade bug implementing proper TR-069 msg s…

### DIFF
--- a/simulator.js
+++ b/simulator.js
@@ -149,18 +149,8 @@ function cpeRequest(requestXml) {
     });
     return;
   }
-  const pending = methods.getPending();
-  if (!pending) {
-    sendRequest(null, function (xml) {
-      handleMethod(xml);
-    });
-    return;
-  }
-  pending(function (body, callback) {
-    let xml = createSoapDocument(requestId, body);
-    sendRequest(xml, function (xml) {
-        callback(xml);
-    });
+  sendRequest(null, function (xml) {
+    handleMethod(xml);
   });
 }
 


### PR DESCRIPTION
This pull request refactors how pending transfer completions are handled in the TR-069 server implementation, specifically for file downloads, uploads, or firmware upgrades. Instead of sending `TransferComplete` messages immediately, transfer completion details are now stored and included in the next `Inform` message. This approach improves protocol compliance and simplifies transfer completion handling.

**Transfer Completion Handling**

* Refactored to store pending transfer completion data in a new `pendingTransfers` array, rather than using callback functions in the `pending` array.
* Updated the `Download` method to push transfer details (such as `commandKey`, `startTime`, `faultCode`, and `faultString`) to `pendingTransfers`, which will be processed later.

**Inform Message Construction**

* Modified the `inform` function to check for pending transfers and, if present, include a `TransferComplete` node in the next `cwmp:Inform` message.

**API Changes**

* Renamed and exported the new `getPendingTransfers` function, replacing the previous `getPending`.

**Simulator Integration**

* Removed logic in `simulator.js` related to handling pending transfer callbacks, since transfer completions are now handled within the `Inform` message flow.
