### PR TITLE
PDM-696 Fix the mock behavior and update parameters when a firmware u…

### DIFF
--- a/methods.js
+++ b/methods.js
@@ -496,6 +496,22 @@ function downloadFile(device, commandKey, startTime, url, urlObj, fileType) {
       if (fileType === "1 Firmware Upgrade Image") {
         console.log(`🔄 Firmware upgrade: TransferComplete will be sent, then device will reboot`);
         
+        // Extract the firmware filename from the download URL
+        // Handles both proxy and direct URLs by taking the last path segment
+        // e.g., "http://172.19.0.8:7567/https://hgw-sw-dev.nos.pt/askey/RV5ASK_monolith_20200910124875_1.1.5.1-D31.p7b"
+        //     → "RV5ASK_monolith_20200910124875_1.1.5.1-D31.p7b"
+        console.log(`🔄 The URL for fimware version upgrade: ${url}`);
+        const filenameMatch = url.match(/\/([^/]+)$/);
+        if (filenameMatch) {
+          device._targetFirmwareVersion = filenameMatch[1];
+          console.log(`📦 Target firmware version extracted from URL: ${device._targetFirmwareVersion}`);
+        } else {
+          // Fallback: use the filename as version identifier
+          const filename = url.split("/").pop() || "unknown";
+          device._targetFirmwareVersion = filename;
+          console.log(`⚠️ Could not extract version from URL, using filename: ${device._targetFirmwareVersion}`);
+        }
+
         // Set a flag to trigger reboot after TransferComplete
         device._pendingReboot = true;
         device._firmwareUpgrade = true;

--- a/simulator.js
+++ b/simulator.js
@@ -180,17 +180,21 @@ function handleMethod(xml) {
     // Check if firmware reboot is pending AND we're ending a TransferComplete session
     if (device._pendingReboot && device._firmwareUpgrade && device._transferCompleteSession) {
       console.log(`🔄 TransferComplete session ended, initiating reboot for firmware upgrade`);
+      const targetFirmwareVersion = device._targetFirmwareVersion || null;
       delete device._pendingReboot;
       delete device._firmwareUpgrade;
       delete device._transferCompleteSession;
+      delete device._targetFirmwareVersion;
       
       const rebootTimeout = stopSession();
       setTimeout(() => {
         console.log(`🚀 Device booting after firmware upgrade`);
         
         // Update software version to simulate firmware change
-        updateParameter("Device.DeviceInfo.SoftwareVersion", "2.0.0-upgraded");
-        updateParameter("InternetGatewayDevice.DeviceInfo.SoftwareVersion", "2.0.0-upgraded");
+        if (targetFirmwareVersion) {
+          updateParameter("Device.DeviceInfo.SoftwareVersion", targetFirmwareVersion);
+          updateParameter("InternetGatewayDevice.DeviceInfo.SoftwareVersion", targetFirmwareVersion);
+        }
         
         startSession("1 BOOT,M Download,4 VALUE CHANGE");
       }, rebootTimeout);
@@ -313,6 +317,7 @@ function start(dataModel, serialNumber, macAddress, acsUrl, defaultTimeout) {
   delete device._firmwareUpgrade;
   delete device._transferCompleteSession;
   delete device._downloadInProgress;
+  delete device._targetFirmwareVersion;
   device._activeDownloadRequest = null;
   
   if (device["DeviceID.SerialNumber"])


### PR DESCRIPTION
This pull request improves the firmware upgrade simulation logic by accurately tracking and updating the device's software version based on the firmware filename extracted from the download URL. The changes focus on extracting the firmware version, updating device state after the upgrade, and cleaning up related properties.

Firmware version extraction and tracking:

* Added logic in `downloadFile` (`methods.js`) to extract the firmware filename from the download URL and store it in `device._targetFirmwareVersion`, ensuring the correct version is tracked for the upgrade process.

Firmware upgrade handling and cleanup:

* Modified `handleMethod` (`simulator.js`) to update the device's software version using the extracted firmware filename after a firmware upgrade and to clean up the `device._targetFirmwareVersion` property after the upgrade completes.
* Ensured `device._targetFirmwareVersion` is deleted during device initialization in `start` (`simulator.js`) to prevent stale version data from affecting future upgrades.